### PR TITLE
V1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "aws-sdk": "^2.1336.0",
     "axios": "^0.24.0",
     "electron-dl": "^3.3.0",
     "maplibre-gl": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safedocs-app",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "author": "NASA JPL",
   "description": "DARPA Safedocs file observatory",

--- a/public/electron.js
+++ b/public/electron.js
@@ -202,6 +202,9 @@ app.whenReady().then(() => {
             );
 
             await fs.writeFile(downloadedFilePath, data);
+          })
+          .catch((err) => {
+            console.error(err);
           });
       } else if (!info.useRawFileLocation) {
         download(BrowserWindow.getFocusedWindow(), info.url, {
@@ -400,6 +403,13 @@ app.whenReady().then(() => {
                     );
 
                     fs.writeFile(destinationPath, data);
+                    window.webContents.send(
+                      "download complete",
+                      destinationPath
+                    );
+                  })
+                  .catch((err) => {
+                    console.error(err);
                   });
               } else if (!info.useRawFileLocation) {
                 download(BrowserWindow.getFocusedWindow(), url, {
@@ -414,10 +424,7 @@ app.whenReady().then(() => {
                 );
                 if (fs.existsSync(url)) {
                   fs.copyFileSync(url, destinationPath);
-                  window.webContents.send(
-                    "download complete",
-                    response.filePaths[0]
-                  );
+                  window.webContents.send("download complete", destinationPath);
                 }
               }
             });

--- a/src/components/DownloadButton.tsx
+++ b/src/components/DownloadButton.tsx
@@ -40,7 +40,7 @@ import useStore from "../utils/store";
 // @ts-ignore
 const { ipcRenderer } = window.require("electron");
 
-interface Props {}
+interface Props { }
 
 const DownloadButton: FC<Props> = () => {
   const [openOptions, setOpenOptions] = useState(false);
@@ -52,7 +52,11 @@ const DownloadButton: FC<Props> = () => {
   const totalDocumentCount = useStore((state) => state.totalDocumentCount);
   const getRandomDocumentsDownloadPaths = useStore((state) => state.getRandomDocumentsDownloadPaths);
   const getDocumentsDownloadPaths = useStore((state) => state.getDocumentsDownloadPaths);
-  const useRawFileLocation = useStore((state) => state.useRawFileLocation);
+  const downloadMode = useStore((state) => state.downloadMode);
+
+  const s3BucketName = useStore((state) => state.s3BucketName);
+  const s3AccessKeyID = useStore((state) => state.s3AccessKeyID);
+  const s3SecretAccessKey = useStore((state) => state.s3SecretAccessKey);
 
   const [downloadMessage, setDownloadMessage] = useState("");
 
@@ -104,9 +108,12 @@ const DownloadButton: FC<Props> = () => {
           <MenuItem
             onClick={() => {
               const urls = getDocumentsDownloadPaths(selectedDocuments);
-              console.log("DOWNLOADING", selectedDocuments, urls);
               ipcRenderer.send("download", {
-                useRawFileLocation: useRawFileLocation,
+                useRawFileLocation: downloadMode === "local",
+                useS3: downloadMode === "s3",
+                s3BucketName,
+                s3AccessKeyID,
+                s3SecretAccessKey,
                 urls,
               });
               setSelectedDocuments([]);
@@ -123,9 +130,12 @@ const DownloadButton: FC<Props> = () => {
                 key={`count-${count}`}
                 onClick={() => {
                   getRandomDocumentsDownloadPaths(count).then((urls: string[]) => {
-                    console.log("DOWNLOAD RANDOM", count, urls);
                     ipcRenderer.send("download", {
-                      useRawFileLocation: useRawFileLocation,
+                      useRawFileLocation: downloadMode === "local",
+                      useS3: downloadMode === "s3",
+                      s3BucketName,
+                      s3AccessKeyID,
+                      s3SecretAccessKey,
                       urls,
                     });
                   });

--- a/src/components/SearchTable.tsx
+++ b/src/components/SearchTable.tsx
@@ -200,9 +200,13 @@ const RowColumnDetail = ({ column, value }: { column: string; value: string }) =
 const RowDetail = ({ row }: { row: any }) => {
   return (
     <div>
-      {Object.entries(row).map(([column, value], i) => (
-        <RowColumnDetail key={`${column}-${i}`} column={column} value={value as string} />
-      ))}
+      {Object.entries(row).map(([column, value], i) => {
+        if (Array.isArray(value)) {
+          value = `[${value.join(", ")}]`;
+        }
+
+        return <RowColumnDetail key={`${column}-${i}`} column={column} value={value as string} />;
+      })}
     </div>
   );
 };

--- a/src/components/VisualizationTabs/HexEditor.tsx
+++ b/src/components/VisualizationTabs/HexEditor.tsx
@@ -124,6 +124,7 @@ const HexEditor: FC = () => {
         flexDirection: "column",
       }}
     >
+      <h4 style={{ marginBottom: 0 }}><i>Trail of Bits Polyfile</i> Hex Editor</h4>
       <h5 style={{ marginBottom: 0 }}>Select a document from the table to generate and view</h5>
       <span style={{ fontSize: "12px", marginBottom: "15px" }}>
         This may take a couple minutes depending on the size of the document.
@@ -243,7 +244,7 @@ const HexEditor: FC = () => {
         />
       </FormControl>
       <FormControl style={{ width: "488px", marginTop: "15px" }}>
-        <InputLabel id="existing-file-select-label">Open Generated Hex Editor File</InputLabel>
+        <InputLabel id="existing-file-select-label">Open Polyfile Generated Hex Editor File</InputLabel>
         <Select
           value=""
           id="existing-file-select"

--- a/src/components/VisualizationTabs/HexEditor.tsx
+++ b/src/components/VisualizationTabs/HexEditor.tsx
@@ -49,7 +49,12 @@ const path = window.require("path");
 
 const HexEditor: FC = () => {
   const rawFileLocation = useStore((state) => state.rawFileLocation);
-  const useRawFileLocation = useStore((state) => state.useRawFileLocation);
+  const downloadMode = useStore((state) => state.downloadMode);
+
+  const s3BucketName = useStore((state) => state.s3BucketName);
+  const s3AccessKeyID = useStore((state) => state.s3AccessKeyID);
+  const s3SecretAccessKey = useStore((state) => state.s3SecretAccessKey);
+
   const selectedIndices = useStore((state) => state.selectedDocuments);
   const getDocumentsDownloadPaths = useStore((state) => state.getDocumentsDownloadPaths);
 
@@ -159,7 +164,11 @@ const HexEditor: FC = () => {
                   url: hexEditorFile,
                   path: hexEditorFile,
                   outputFile: path.join(hexEditorFileDirectory, `${hexEditorFile.split("/").pop()}.html`),
-                  useRawFileLocation: useRawFileLocation || !hexEditorFile.startsWith("http"),
+                  useRawFileLocation: downloadMode === "local" && !hexEditorFile.startsWith("http"),
+                  useS3: downloadMode === "s3",
+                  s3BucketName,
+                  s3AccessKeyID,
+                  s3SecretAccessKey,
                 });
                 setHexEditorLoading(true);
               }

--- a/src/components/Visualizations.tsx
+++ b/src/components/Visualizations.tsx
@@ -332,10 +332,30 @@ const Visualizations: FC = () => {
 
   const formattedSuggestions = useMemo(() => {
     if (!suggestions || !Object.keys(suggestions).length) return [];
-    return Object.entries(suggestions.documents.aggregations).map(([term, meta]: [term: string, meta: any]) => ({
+    let data = Object.entries(suggestions.documents.aggregations).map(([term, meta]: [term: string, meta: any]) => ({
       label: term,
       count: meta.doc_count,
     }));
+
+    data.sort((a, b) => {
+      if (a.count === b.count) {
+        // If text is the same and ends with an number, sort by number
+        // Ex. Font8 < Font10
+        let aLabel = a.label.match(/(?<label>[^0-9]*)(?<number>\d+$)/);
+        let bLabel = b.label.match(/(?<label>[^0-9]*)(?<number>\d+$)/);
+        if (aLabel && bLabel && aLabel.groups?.label === bLabel.groups?.label) {
+          const aNum = parseInt(aLabel.groups?.number || "0");
+          const bNum = parseInt(bLabel.groups?.number || "0");
+
+          return bNum - aNum;
+        }
+
+        return a.label < b.label ? -1 : 1;
+      }
+      return b.count - a.count;
+    });
+
+    return data;
   }, [suggestions]);
 
   const formattedCompletions = useMemo(() => {

--- a/src/scss/Header.scss
+++ b/src/scss/Header.scss
@@ -58,18 +58,8 @@ header {
 
   div.MuiOutlinedInput-root {
     background: white;
-    width: 15ch;
+    width: 40ch;
     transition: all 0.5s ease;
-
-    &.Mui-focused {
-      width: 40ch;
-    }
-  }
-
-  div.Mui-focused {
-    div.MuiOutlinedInput-root {
-      width: 40ch;
-    }
   }
 
   input {

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -295,6 +295,7 @@ const useStore = create<Store>(
           suggestions: {},
           completions: [],
           geoLocations: [],
+          sigTerms: {}
         }));
         if (!index || !get().getSearchURL()) {
           set({ validIndex: false, loadingIndex: false });
@@ -370,6 +371,7 @@ const useStore = create<Store>(
           completions: [],
           aggregations: {},
           geoLocations: [],
+          sigTerms: {}
         }),
       suggestionField: "q_keys",
       setSuggestionField: (suggestionField) => {

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -62,6 +62,8 @@ export type Filter = {
   value: string;
 };
 
+export type DownloadMode = "api" | "local" | "s3";
+
 export type Store = {
   esURL: string;
   setEsURL: (esURL: string) => void;
@@ -78,8 +80,14 @@ export type Store = {
   setDownloadAPI: (API: string) => void;
   rawFileLocation: string;
   setRawFileLocation: (location: string) => void;
-  useRawFileLocation: boolean;
-  setUseRawFileLocation: (useRawFileLocation: boolean) => void;
+  downloadMode: DownloadMode;
+  setDownloadMode: (downloadMode: DownloadMode) => void;
+  s3BucketName: string;
+  setS3BucketName: (s3BucketName: string) => void;
+  s3AccessKeyID: string;
+  setS3AccessKeyID: (s3AccessKeyID: string) => void;
+  s3SecretAccessKey: string;
+  setS3SecretAccessKey: (s3SecretAccessKey: string) => void;
   index: string;
   validIndex: boolean;
   loadingIndex: boolean;
@@ -190,7 +198,10 @@ export const persistentProps: NonFunctionPropertyNames<Store>[] = [
   "downloadAPI",
   "downloadPathField",
   "rawFileLocation",
-  "useRawFileLocation",
+  "downloadMode",
+  "s3BucketName",
+  "s3AccessKeyID",
+  "s3SecretAccessKey",
   "index",
   "activeField",
   "activeYField",
@@ -275,8 +286,14 @@ const useStore = create<Store>(
       setDownloadAPI: (downloadAPI) => set(() => ({ downloadAPI })),
       rawFileLocation: "",
       setRawFileLocation: (rawFileLocation) => set(() => ({ rawFileLocation })),
-      useRawFileLocation: false,
-      setUseRawFileLocation: (useRawFileLocation) => set(() => ({ useRawFileLocation })),
+      downloadMode: "api",
+      setDownloadMode: (downloadMode) => set(() => ({ downloadMode })),
+      s3BucketName: "",
+      setS3BucketName: (s3BucketName) => set(() => ({ s3BucketName })),
+      s3AccessKeyID: "",
+      setS3AccessKeyID: (s3AccessKeyID) => set(() => ({ s3AccessKeyID })),
+      s3SecretAccessKey: "",
+      setS3SecretAccessKey: (s3SecretAccessKey) => set(() => ({ s3SecretAccessKey })),
       index: "",
       validIndex: false,
       loadingIndex: false,
@@ -844,7 +861,7 @@ const useStore = create<Store>(
           });
       },
       getDocumentsDownloadPaths: (docIDs) => {
-        if (!get().useRawFileLocation) {
+        if (get().downloadMode === "local") {
           return [
             encodeURI(
               `${get().downloadAPI}?${docIDs
@@ -852,6 +869,8 @@ const useStore = create<Store>(
                 .join("&")}`
             ),
           ];
+        } else if (get().downloadMode === "s3") {
+          return docIDs.map((docID) => get().documents[docID]._source[get().downloadPathField]);
         } else {
           return docIDs.map((docID) =>
             path.join(
@@ -879,7 +898,7 @@ const useStore = create<Store>(
         return timedAxios.post(searchURL, query).then((response) => {
           let responseDocuments = get().useEsAPI ? response.data.documents : response.data;
           let documents = responseDocuments.hits.hits;
-          if (!get().useRawFileLocation) {
+          if (get().downloadMode === "local") {
             return [
               encodeURI(
                 `${get().downloadAPI}?${documents
@@ -887,6 +906,8 @@ const useStore = create<Store>(
                   .join("&")}`
               ),
             ];
+          } else if (get().downloadMode === "s3") {
+            return documents.map((document: any) => document._source[get().downloadPathField]);
           } else {
             return documents.map((document: any) => {
               return path.join(
@@ -964,7 +985,10 @@ const useStore = create<Store>(
           downloadAPI: "https://api.safedocs.xyz/v1/files",
           downloadPathField: "",
           rawFileLocation: "",
-          useRawFileLocation: false,
+          downloadMode: "api",
+          s3BucketName: "",
+          s3AccessKeyID: "",
+          s3SecretAccessKey: "",
           index: "",
           sigTermsField: "tk_creator_tool",
           suggestionField: "q_keys",

--- a/src/utils/store.tsx
+++ b/src/utils/store.tsx
@@ -459,10 +459,10 @@ const useStore = create<Store>(
                 let options = [suggestions.text, ...suggestions.options.map((option: any) => option.text)];
 
                 let countQuery: Record<string, any> = {
-                  query: infiniteQuery.query,
+                  query: { match_all: {} },
                   aggs: {},
                   track_total_hits: true,
-                  size: 0,
+                  size: 1000,
                 };
 
                 options.forEach((option) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3689,6 +3689,27 @@ autoprefixer@^9.6.1:
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
+available-typed-arrays@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
+  integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+aws-sdk@^2.1336.0:
+  version "2.1336.0"
+  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1336.0.tgz#105527471320a9183e03d5fb42cc6fa2d1e270ec"
+  integrity sha512-DmnuMr1tK30At8n4gAHohb3nP/qCgUNjTrgZSl1+6gK8U5Yt6qPSqHM3ieWTm6VMSQTRp9aaR91l6soznnuxuA==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    util "^0.12.4"
+    uuid "8.0.0"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -4236,7 +4257,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
+buffer@4.9.2, buffer@^4.3.0:
   version "4.9.2"
   resolved "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
   integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
@@ -6627,6 +6648,11 @@ eventemitter3@^4.0.0, eventemitter3@^4.0.1:
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==
+
 events@^3.0.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -7052,6 +7078,13 @@ follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4:
   resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -7253,6 +7286,15 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+get-intrinsic@^1.1.3:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz#7ad1dc0535f3a2904bba075772763e5051f6d05f"
+  integrity sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.3"
 
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
@@ -7465,6 +7507,13 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
+
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.npmjs.org/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -7586,6 +7635,11 @@ has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-tostringtag@^1.0.0:
   version "1.0.0"
@@ -7914,6 +7968,11 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
 ieee754@^1.1.12, ieee754@^1.1.13, ieee754@^1.1.4:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
@@ -8188,6 +8247,11 @@ is-buffer@^1.1.5:
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
+is-callable@^1.1.3:
+  version "1.2.7"
+  resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
+
 is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
@@ -8313,6 +8377,13 @@ is-generator-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
+is-generator-function@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz#f1558baf1ac17e0deea7c0415c438351ff2b3c72"
+  integrity sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==
+  dependencies:
+    has-tostringtag "^1.0.0"
 
 is-glob@^3.1.0:
   version "3.1.0"
@@ -8487,6 +8558,17 @@ is-symbol@^1.0.2, is-symbol@^1.0.3:
   integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
   dependencies:
     has-symbols "^1.0.2"
+
+is-typed-array@^1.1.10, is-typed-array@^1.1.3:
+  version "1.1.10"
+  resolved "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz#36a5b5cb4189b575d1a3e4b08536bfb485801e3f"
+  integrity sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
 
 is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
@@ -9094,6 +9176,11 @@ jest@26.6.0:
     "@jest/core" "^26.6.0"
     import-local "^3.0.2"
     jest-cli "^26.6.0"
+
+jmespath@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
 joi@^17.4.0:
   version "17.5.0"
@@ -12938,7 +13025,12 @@ sass@^1.44.0:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==
+
+sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -14510,6 +14602,14 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.npmjs.org/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -14570,6 +14670,17 @@ util@^0.11.0:
   dependencies:
     inherits "2.0.3"
 
+util@^0.12.4:
+  version "0.12.5"
+  resolved "https://registry.npmjs.org/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
+  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    which-typed-array "^1.1.2"
+
 utila@~0.4:
   version "0.4.0"
   resolved "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
@@ -14579,6 +14690,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
+  integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
@@ -14931,6 +15047,18 @@ which-module@^2.0.0:
   resolved "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
+which-typed-array@^1.1.2:
+  version "1.1.9"
+  resolved "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz#307cf898025848cf995e795e8423c7f337efbde6"
+  integrity sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==
+  dependencies:
+    available-typed-arrays "^1.0.5"
+    call-bind "^1.0.2"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    has-tostringtag "^1.0.0"
+    is-typed-array "^1.1.10"
+
 which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -15195,10 +15323,23 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
 xmlbuilder@>=11.0.1, xmlbuilder@^15.1.1:
   version "15.1.1"
   resolved "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
   integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha512-7YXTQc3P2l9+0rjaUbLwMKRhtmwg1M1eDf6nag7urC7pIPYLD9W/jmzQ4ptRSUbodw5S0jfoGTflLemQibSpeQ==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
- Attributes Polyfile in Hex Editor tab
- Fixes similarity table sorting logic
  - Sorts by count and if tokens have the same count, then it sorts by name, but if the name ends in a number and the base is the same, then it sorts desc by number (Ex. `/Font21` > `/Font3`)
- Adds support for arrays in table view detail row
- Fixes refreshing issue with Sig Terms viz where stale data was being kept after a new query was initiated
- Adds support for multiple filter selections in the same category (filters in the same category operate with `OR` logic)
- Adds file downloading support from S3
  - Requires `Bucket Name`, `Access Key ID`, and `Secret Access Key` to be configured from settings